### PR TITLE
fix typo, default to scss to prevent pleeease error on initial build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Some boilerplate code for static site generation
 1. Simply run `grunt build` to see that everything works
 
 ## How to work with this?
-You can run `grunt --dev` while developing. This starts a new web server on port 3000 (http://localhost:3000/).
+You can run `grunt dev` while developing. This starts a new web server on port 3000 (http://localhost:3000/).
 After every change the affected files are regenerated.
 
 ## Available Grunt tasks

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -185,8 +185,8 @@ module.exports = function(grunt) {
     });
 
     // Use either of these two tasks, depending on whether you use less or scss
-    grunt.registerTask('buildCSS', ['less', 'pleeease']);
-    //grunt.registerTask('buildCSS', ['sass', 'pleeease']);
+    //grunt.registerTask('buildCSS', ['less', 'pleeease']);
+    grunt.registerTask('buildCSS', ['sass', 'pleeease']);
 
     // Use either of these two tasks, depending on whether you use RequireJS or WebPack
     grunt.registerTask('buildJS', ['requirejs']);


### PR DESCRIPTION
Hey @bdadam, after getting started with your static site boilerplate and loving it, I noticed 2 quick cosmetic changes to help another user get running faster:
- typo in README (`--dev` different from `dev`)
- swapped default grunt task from less to sass. pleeease was giving an error, I suppose because less file was empty? I saw you already had content in the scss file so I swapped tasks!

``` bash
Running "less:main" (less) task
>> 1 stylesheet created.

Running "pleeease:dist" (pleeease) task
>> Error: CSS string or CSS AST data was not provided to pleeease.process()
Warning:  Use --force to continue.

Aborted due to warnings.
```

Thanks for the awesome repo :)
